### PR TITLE
One line fix: allow n-dimensional input to periodic activation functions

### DIFF
--- a/periodic_activations.py
+++ b/periodic_activations.py
@@ -11,7 +11,7 @@ def t2v(tau, f, out_features, w, b, w0, b0, arg=None):
         v1 = f(torch.matmul(tau, w) + b)
     v2 = torch.matmul(tau, w0) + b0
     #print(v1.shape)
-    return torch.cat([v1, v2], 1)
+    return torch.cat([v1, v2], -1)
 
 class SineActivation(nn.Module):
     def __init__(self, in_features, out_features):


### PR DESCRIPTION
Currently, only 2d tensors can be accepted as input to periodic activation functions (i.e. this implementation assumes inputs are formatted as batch x time); concatenating along the last dimension rather than the 2nd dimension allows for n-dimensional tensor inputs without breaking existing functionality.